### PR TITLE
Parameterize repository path

### DIFF
--- a/src/git/config.yml
+++ b/src/git/config.yml
@@ -15,4 +15,7 @@ jobs:
       - checkout
       - run: ssh-add ~/project/.ssh/id_rsa
       - git/checkout
-      - run: test $(git log --pretty=oneline | wc -l) -eq 1
+      - run: cd /home/app/current && test $(git log --pretty=oneline | wc -l) -eq 1
+      - git/checkout:
+          repo_path: /home/some/other/path
+      - run: cd /home/some/other/path && test $(git log --pretty=oneline | wc -l) -eq 1

--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -5,6 +5,10 @@ description: |
 
 commands:
   checkout:
+    parameters:
+      repo_path:
+        default: /home/app/current
+        type: string
     steps:
       - run:
           name: Set up HOME environment variable
@@ -36,13 +40,13 @@ commands:
       - run:
           name: Set up git repository
           command: |
-            if [ -e /home/app/current/.git ]
+            if [ -e << parameters.repo_path >>/.git ]
             then
-              cd /home/app/current
+              cd << parameters.repo_path >>
               git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
             else
-              mkdir -p /home/app/current
-              cd /home/app/current
+              mkdir -p << parameters.repo_path >>
+              cd << parameters.repo_path >>
               git clone --depth 1 "$CIRCLE_REPOSITORY_URL" .
             fi
       - run:


### PR DESCRIPTION
Looks like `/home/app/current` is specific to certain images.

If I use `git/checkout` on a Node based repo then it seems it cannot create a directory at `/home/app/current`