### PR TITLE
Bugfix: allow fetching non-head SHA1 of a branch

### DIFF
--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -56,7 +56,7 @@ commands:
             then
               git fetch --depth 1 --force origin "refs/tags/$CIRCLE_TAG"
             else
-              git fetch --depth 1 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+              git fetch --force origin "$CIRCLE_SHA1:remotes/origin/$CIRCLE_BRANCH"
             fi
       - run:
           name: Checkout branch

--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -56,7 +56,7 @@ commands:
             then
               git fetch --depth 1 --force origin "refs/tags/$CIRCLE_TAG"
             else
-              git fetch --force origin "$CIRCLE_SHA1:remotes/origin/$CIRCLE_BRANCH"
+              git fetch --depth 1 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
       - run:
           name: Checkout branch

--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -56,7 +56,7 @@ commands:
             then
               git fetch --depth 1 --force origin "refs/tags/$CIRCLE_TAG"
             else
-              git fetch --depth 1 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
+              git fetch --depth 5 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
       - run:
           name: Checkout branch


### PR DESCRIPTION
Scenario:

- Two commits are pushed to a branch in a rapid manner (so fast that CI is not able to fetch the appropriate branch for the first commit before the second commit is pushed)
- The first CI build will fail because the head of the branch is past the specified commit
- The second CI build will succeed because the SHA1 is the head of the branch

While the latest commit of the branch is still built, this is unexpected behavior and is considered a bug.
