### PR TITLE
Fixing CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
       - cli/install
       - checkout
       - run: cp -r ~/.ssh ~/project
+      - run: git add --all
       - run: sed -i -e 's/$CIRCLE_SHA1/'$CIRCLE_SHA1'/g' src/git/config.yml
       - run: circleci config process src/git/config.yml > src/git/processed_config.yml
       - run: circleci local execute -c src/git/processed_config.yml | tee local_build_output.txt /dev/stderr | tail -n 1 | grep "Success"

--- a/src/git/config.yml
+++ b/src/git/config.yml
@@ -14,8 +14,10 @@ jobs:
     steps:
       - checkout
       - run: ssh-add ~/project/.ssh/id_rsa
+      - run: mkdir ~/project-test-1 && cd ~/project-test-1
       - git/checkout
       - run: cd /home/app/current && test $(git rev-list --all --count) -eq 1
+      - run: mkdir ~/project-test-2 && cd ~/project-test-2
       - git/checkout:
           repo_path: /home/some/other/path
       - run: cd /home/some/other/path && test $(git rev-list --all --count) -eq 1

--- a/src/git/config.yml
+++ b/src/git/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - run: ssh-add ~/project/.ssh/id_rsa
       - git/checkout
-      - run: cd /home/app/current && test $(git log --pretty=oneline | wc -l) -eq 1
+      - run: cd /home/app/current && test $(git rev-list --all --count) -eq 1
       - git/checkout:
           repo_path: /home/some/other/path
-      - run: cd /home/some/other/path && test $(git log --pretty=oneline | wc -l) -eq 1
+      - run: cd /home/some/other/path && test $(git rev-list --all --count) -eq 1

--- a/src/git/config.yml
+++ b/src/git/config.yml
@@ -15,7 +15,7 @@ jobs:
       - checkout
       - run: ssh-add ~/project/.ssh/id_rsa
       - git/checkout
-      - run: cd /home/app/current && test $(git rev-list --all --count) -eq 1
+      - run: cd /home/app/current && test $(git rev-list --all --count) -eq 5
       - git/checkout:
           repo_path: /home/some/other/path
-      - run: cd /home/some/other/path && test $(git rev-list --all --count) -eq 1
+      - run: cd /home/some/other/path && test $(git rev-list --all --count) -eq 5

--- a/src/git/config.yml
+++ b/src/git/config.yml
@@ -15,7 +15,13 @@ jobs:
       - checkout
       - run: ssh-add ~/project/.ssh/id_rsa
       - git/checkout
-      - run: cd /home/app/current && test $(git rev-list --all --count) -eq 5
+      - run: |
+          # Default directory is /home/app/current
+          cd /home/app/current
+          # Since the repo has many git commits, it will fetch 5 commits on the branch plus the latest master
+          test $(git rev-list --all --count) -eq 6
       - git/checkout:
           repo_path: /home/some/other/path
-      - run: cd /home/some/other/path && test $(git rev-list --all --count) -eq 5
+      - run: |
+          cd /home/some/other/path
+          test $(git rev-list --all --count) -eq 6

--- a/src/git/config.yml
+++ b/src/git/config.yml
@@ -14,10 +14,8 @@ jobs:
     steps:
       - checkout
       - run: ssh-add ~/project/.ssh/id_rsa
-      - run: mkdir ~/project-test-1 && cd ~/project-test-1
       - git/checkout
       - run: cd /home/app/current && test $(git rev-list --all --count) -eq 1
-      - run: mkdir ~/project-test-2 && cd ~/project-test-2
       - git/checkout:
           repo_path: /home/some/other/path
       - run: cd /home/some/other/path && test $(git rev-list --all --count) -eq 1

--- a/src/git/config.yml
+++ b/src/git/config.yml
@@ -19,9 +19,9 @@ jobs:
           # Default directory is /home/app/current
           cd /home/app/current
           # Since the repo has many git commits, it will fetch 5 commits on the branch plus the latest master
-          test $(git rev-list --all --count) -eq 6
+          test $(git rev-list --count "$CIRCLE_BRANCH") -le 5
       - git/checkout:
           repo_path: /home/some/other/path
       - run: |
           cd /home/some/other/path
-          test $(git rev-list --all --count) -eq 6
+          test $(git rev-list --count "$CIRCLE_BRANCH") -le 5


### PR DESCRIPTION
Theory: CircleCI changed how they ported code into the VM. I think we used to tar a different set of files but it changed. 

A couple of problems:

1. We no longer were copying the SSH key to test git checkout operations
2. We were asserting only 1 commit is being pulled but the actual code is pulling in 5 per branch. 

Solutions:

1. Stage (but never commit) the SSH key before starting a VM
2. Update assertion count against a single branch