### PR TITLE
Fix Fix CI

### DIFF
--- a/src/git/config.yml
+++ b/src/git/config.yml
@@ -19,9 +19,9 @@ jobs:
           # Default directory is /home/app/current
           cd /home/app/current
           # Since the repo has many git commits, it will fetch 5 commits on the branch plus the latest master
-          test $(git rev-list --count "$CIRCLE_BRANCH") -le 5
+          test $(git rev-list --count "$CIRCLE_BRANCH" .) -le 5
       - git/checkout:
           repo_path: /home/some/other/path
       - run: |
           cd /home/some/other/path
-          test $(git rev-list --count "$CIRCLE_BRANCH") -le 5
+          test $(git rev-list --count "$CIRCLE_BRANCH" .) -le 5


### PR DESCRIPTION
Follow up to https://github.com/mavenlink/orbs/pull/13

Once I merged into `master`, it failed CI. I think it has to do with specifying the path to the `git rev-list`.